### PR TITLE
Move transport related options to correct place

### DIFF
--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -202,6 +202,9 @@
                     ? this.sipInfo.transport.toLowerCase() + '://' + this.sipInfo.outboundProxy
                     : this.sipInfo.wsServers,
                 traceSip: true,
+                maxReconnectionAttempts: options.maxReconnectionAttempts || 3,
+                reconnectionTimeout: options.reconnectionTimeout || 5,
+                connectionTimeout: options.connectionTimeout || 5
             },
             authorizationUser: this.sipInfo.authorizationId,
             password: this.sipInfo.password,
@@ -215,11 +218,7 @@
             domain: this.sipInfo.domain,
             autostart: true,
             register: true,
-            userAgentString: userAgentString,
-
-            wsServerMaxReconnection: options.wsServerMaxReconnection || 3,
-            connectionRecoveryMaxInterval: options.connectionRecoveryMaxInterval || 60,
-            connectionRecoveryMinInterval: options.connectionRecoveryMinInterval || 2,
+            userAgentString: userAgentString,           
             sessionDescriptionHandlerFactoryOptions: sessionDescriptionHandlerFactoryOptions,
             sessionDescriptionHandlerFactory : sessionDescriptionHandlerFactory
         };


### PR DESCRIPTION
options 
            wsServerMaxReconnection: options.wsServerMaxReconnection || 3,
            connectionRecoveryMaxInterval: options.connectionRecoveryMaxInterval || 60,
            connectionRecoveryMinInterval: options.connectionRecoveryMinInterval || 2,
are not applicable any more
Use transportOptions object instead