### PR TITLE
userAgent.start() instead of userAgent.register()

### DIFF
--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -269,7 +269,7 @@
         this.userAgent.sendMessage = sendMessage;
         this.userAgent.transport._onMessage = this.userAgent.transport.onMessage;
         this.userAgent.transport.onMessage = onMessage;
-        this.userAgent.register();
+        this.userAgent.start();
     }
 
     /*--------------------------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
userAgent.register() do register without checking if WS connection already open. 
use start() instead, which starts WS connection and register once it open;