### PR TITLE
remove double registration

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -233,7 +233,7 @@
 <script type="text/javascript" src="//cdn.jsdelivr.net/fetch/2.0.1/fetch.min.js"></script>
 <script type="text/javascript" src="//cdn.jsdelivr.net/es6-promise/3.1.2/es6-promise.js"></script>
 <script type="text/javascript" src="//cdn.pubnub.com/sdk/javascript/pubnub.4.4.2.js"></script>
-<script type="text/javascript" src="//cdn.rawgit.com/onsip/SIP.js/0.10.0/dist/sip-0.10.0.js"></script>
+<script type="text/javascript" src="//cdn.rawgit.com/onsip/SIP.js/0.11.2/dist/sip-0.11.2.js"></script>
 <script type="text/javascript" src="//cdn.rawgit.com/ringcentral/ringcentral-js/3.1.0/build/ringcentral.js"></script>
 <script type="text/javascript" src="../src/ringcentral-web-phone.js"></script>
 <script type="text/javascript" src="index.js"></script>

--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -271,7 +271,7 @@
 
     /*--------------------------------------------------------------------------------------------------------------------*/
 
-    WebPhone.version = '0.4.6';
+    WebPhone.version = '0.5.0';
     WebPhone.uuid = uuid;
     WebPhone.delay = delay;
     WebPhone.extend = extend;

--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -163,11 +163,10 @@
         );
 
         var modifiers = options.modifiers || [];
-        modifiers.push(SIP.WebRTC.Modifiers.stripTcpCandidates);
+        modifiers.push(SIP.Web.Modifiers.stripG722);
+        modifiers.push(SIP.Web.Modifiers.stripTcpCandidates);
 
-
-
-        var sessionDescriptionHandlerFactoryOptions = options.sessionDescriptionHandlerFactory || {
+        var sessionDescriptionHandlerFactoryOptions = options.sessionDescriptionHandlerFactoryOptions || {
             peerConnectionOptions: {
                 iceCheckingTimeout: this.sipInfo.iceCheckingTimeout || this.sipInfo.iceGatheringTimeout || 500,
                     rtcConfiguration: {
@@ -197,16 +196,21 @@
 
         var configuration = {
             uri: 'sip:' + this.sipInfo.username + '@' + this.sipInfo.domain,
-            wsServers: this.sipInfo.outboundProxy && this.sipInfo.transport
-                ? this.sipInfo.transport.toLowerCase() + '://' + this.sipInfo.outboundProxy
-                : this.sipInfo.wsServers,
+
+            transportOptions: {
+                wsServers: this.sipInfo.outboundProxy && this.sipInfo.transport
+                    ? this.sipInfo.transport.toLowerCase() + '://' + this.sipInfo.outboundProxy
+                    : this.sipInfo.wsServers,
+                traceSip: true,
+            },
             authorizationUser: this.sipInfo.authorizationId,
             password: this.sipInfo.password,
-            traceSip: true,
             stunServers: this.sipInfo.stunServers || ['stun:74.125.194.127:19302'], //FIXME Hardcoded?
             turnServers: [],
             log: {
-                level: options.logLevel || 1 //FIXME LOG LEVEL 3
+                level: options.logLevel || 1 ,//FIXME LOG LEVEL 3
+                builtinEnabled : options.builtinEnabled || true,
+                connector  : options.connector|| null
             },
             domain: this.sipInfo.domain,
             autostart: true,

--- a/src/ringcentral-web-phone.js
+++ b/src/ringcentral-web-phone.js
@@ -268,8 +268,7 @@
         this.userAgent.createRcMessage = createRcMessage;
         this.userAgent.sendMessage = sendMessage;
         this.userAgent.transport._onMessage = this.userAgent.transport.onMessage;
-        this.userAgent.transport.onMessage = onMessage;
-        this.userAgent.register();
+        this.userAgent.transport.onMessage = onMessage;       
     }
 
     /*--------------------------------------------------------------------------------------------------------------------*/


### PR DESCRIPTION
remove  this.userAgent.register(); that causes registeration fail issue. 
When you execute  this.userAgent.register(); WS is not open yet, so request failed;
putting params:
            autostart: true,
            register: true,
is enough, it make register by itself, no need to manually register it again;